### PR TITLE
Add pdf2txt functionality

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -6,6 +6,18 @@ import openai
 import subprocess
 from multiprocessing import Pool, Process, Manager
 
+from PyPDF2 import PdfReader
+
+
+def pdf2txt(filepath):
+    with open(filepath, "rb") as file:
+        pdf = PdfReader(file)
+        text = ""
+        for page in range(len(pdf.pages)):
+            text += pdf.pages[page].extract_text()
+    return text
+
+
 rr = RoundRobin(['OAI1',
                  'OAI2',
                  'OAI3',
@@ -83,8 +95,9 @@ def process_pdf(url, html=False):
 
     # download this pdf and save it as paper.pdf
     os.system("wget " + url + " --user-agent TryToStopMeFromUsingWgetNow -O paper.pdf")
-    result = subprocess.run(['pdf2txt.py', 'paper.pdf'], stdout=subprocess.PIPE)
-    text = result.stdout.decode('utf-8')
+    # result = subprocess.run(['pdf2txt.py', 'paper.pdf'], stdout=subprocess.PIPE)
+    # text = result.stdout.decode('utf-8')
+    text = pdf2txt('paper.pdf')
 
     # chunk the text up into 1000 word chunks and store them in a list
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 pdfminer.six
 flask
 openai 
+pypdf2~=3.0.1


### PR DESCRIPTION
Hi! Maybe I missed something, but there was no `pdf2txt.py` file. I change it so that it's using a function instead of the file.

Therefore, the lines:

```python
result = subprocess.run(['pdf2txt.py', 'paper.pdf'], stdout=subprocess.PIPE)
text = result.stdout.decode('utf-8')
```

can be turned into:

```python
text = pdf2txt('paper.pdf')
```

where `pdf2txt` is:

```python
def pdf2txt(filepath):
    with open(filepath, "rb") as file:
        pdf = PdfReader(file)
        text = ""
        for page in range(len(pdf.pages)):
            text += pdf.pages[page].extract_text()
    return text
```

And, of course, added this to `requirements.txt`:
```
pypdf2~=3.0.1
```

The idea is fantastic, btw!

![image](https://user-images.githubusercontent.com/81184255/214536062-3ca9b31b-4d51-4ef2-b0b1-14dc7db344c4.png)

![image](https://user-images.githubusercontent.com/81184255/214535959-c040d7fa-b676-499a-850a-98093a037893.png)

